### PR TITLE
Added op and timestamp to CDC files

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Follow the steps to enable supplemental logging and create the directories for t
 Now deploy the DMS stack using
 
 ```bash
-STACK=OracleStack make deploy
+STACK=ReplicationStack make deploy
 ```
 
 **Set values for the environment variables `CDK_DEPLOY_ACCOUNT`, `CDK_DEPLOY_REGION` and `VPC_ID`. In addition, use the values you set in the previous step for `DMS_USER` and `DMS_PASSWORD`.**
@@ -48,4 +48,4 @@ If you wish to deploy in private subnets, change so [here](https://github.com/av
 
 If everything is deployed fine, the connection tests for all the endpoint will pass and you can kick off the database migration task in DMS. The Parquet files will appear in S3, of which the content and types can be checked with a tool such as `parq`. Running a Glue crawler on the bucket will populate a Glue database with the tables where you can check the data types.
 
-Inserting data into the existing tables will be captured by the CDC process of DMS.
+Inserting data into the existing tables will be captured by the CDC process of DMS. Unlike the full load files, these will include an additional column called `Op` which indicates whether the record is the result of an insert (I), update (U) or delete (D). A Glue database and crawler are made available.

--- a/package-lock.json
+++ b/package-lock.json
@@ -120,6 +120,18 @@
         "constructs": "^3.0.4"
       }
     },
+    "@aws-cdk/aws-glue": {
+      "version": "1.66.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-glue/-/aws-glue-1.66.0.tgz",
+      "integrity": "sha512-O5yUBkYe4UeG1xOptXIdIvxHpA4jXj7/HCireWZVgO8dYG+mzvZ1vK7cpbOD9DOi4Pq7iOAOZCeXoac81Ny1tA==",
+      "requires": {
+        "@aws-cdk/aws-iam": "1.66.0",
+        "@aws-cdk/aws-kms": "1.66.0",
+        "@aws-cdk/aws-s3": "1.66.0",
+        "@aws-cdk/core": "1.66.0",
+        "constructs": "^3.0.4"
+      }
+    },
     "@aws-cdk/aws-iam": {
       "version": "1.66.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-iam/-/aws-iam-1.66.0.tgz",
@@ -1925,6 +1937,794 @@
             "aws-sdk": "^2.739.0",
             "glob": "^7.1.6",
             "yargs": "^16.0.3"
+          },
+          "dependencies": {
+            "@aws-cdk/cloud-assembly-schema": {
+              "version": "1.66.0",
+              "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.66.0.tgz",
+              "integrity": "sha512-r5Iyy93qAj22OKTSHL1fXJ5axqd+7qMFV6qM1EEy7iW+0yw1rDNP9wMtZGeil4Hbd37xXKAv9KTigD3nmORgMQ==",
+              "dev": true,
+              "requires": {
+                "jsonschema": "^1.2.7",
+                "semver": "^7.3.2"
+              }
+            },
+            "@aws-cdk/cx-api": {
+              "version": "1.66.0",
+              "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-1.66.0.tgz",
+              "integrity": "sha512-uxhoQFReziEOSf9QEBBRQ9rQroNnMY41ZH+gqgQajMKDNPOZVhZg4K3LMNRF8oCexUfzq/u4rZyOk18rb51IJw==",
+              "dev": true,
+              "requires": {
+                "@aws-cdk/cloud-assembly-schema": "1.66.0",
+                "semver": "^7.3.2"
+              }
+            },
+            "@types/color-name": {
+              "version": "1.1.1",
+              "resolved": "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0",
+              "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+              "dev": true
+            },
+            "ansi-regex": {
+              "version": "5.0.0",
+              "resolved": "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75",
+              "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+              "dev": true
+            },
+            "ansi-styles": {
+              "version": "4.2.1",
+              "resolved": "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.1.tgz#90ae75c424d008d2624c5bf29ead3177ebfcf359",
+              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+              "dev": true,
+              "requires": {
+                "@types/color-name": "^1.1.1",
+                "color-convert": "^2.0.1"
+              }
+            },
+            "archiver": {
+              "version": "5.0.2",
+              "resolved": "https://registry.yarnpkg.com/archiver/-/archiver-5.0.2.tgz#b2c435823499b1f46eb07aa18e7bcb332f6ca3fc",
+              "integrity": "sha512-Tq3yV/T4wxBsD2Wign8W9VQKhaUxzzRmjEiSoOK0SLqPgDP/N1TKdYyBeIEu56T4I9iO4fKTTR0mN9NWkBA0sg==",
+              "dev": true,
+              "requires": {
+                "archiver-utils": "^2.1.0",
+                "async": "^3.2.0",
+                "buffer-crc32": "^0.2.1",
+                "readable-stream": "^3.6.0",
+                "readdir-glob": "^1.0.0",
+                "tar-stream": "^2.1.4",
+                "zip-stream": "^4.0.0"
+              },
+              "dependencies": {
+                "readable-stream": {
+                  "version": "3.6.0",
+                  "resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198",
+                  "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                  "dev": true,
+                  "requires": {
+                    "inherits": "^2.0.3",
+                    "string_decoder": "^1.1.1",
+                    "util-deprecate": "^1.0.1"
+                  }
+                },
+                "safe-buffer": {
+                  "version": "5.2.1",
+                  "resolved": "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6",
+                  "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+                  "dev": true
+                },
+                "string_decoder": {
+                  "version": "1.3.0",
+                  "resolved": "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e",
+                  "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+                  "dev": true,
+                  "requires": {
+                    "safe-buffer": "~5.2.0"
+                  }
+                }
+              }
+            },
+            "archiver-utils": {
+              "version": "2.1.0",
+              "resolved": "https://registry.yarnpkg.com/archiver-utils/-/archiver-utils-2.1.0.tgz#e8a460e94b693c3e3da182a098ca6285ba9249e2",
+              "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+              "dev": true,
+              "requires": {
+                "glob": "^7.1.4",
+                "graceful-fs": "^4.2.0",
+                "lazystream": "^1.0.0",
+                "lodash.defaults": "^4.2.0",
+                "lodash.difference": "^4.5.0",
+                "lodash.flatten": "^4.4.0",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.union": "^4.6.0",
+                "normalize-path": "^3.0.0",
+                "readable-stream": "^2.0.0"
+              }
+            },
+            "async": {
+              "version": "3.2.0",
+              "resolved": "https://registry.yarnpkg.com/async/-/async-3.2.0.tgz#b3a2685c5ebb641d3de02d161002c60fc9f85720",
+              "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
+              "dev": true
+            },
+            "aws-sdk": {
+              "version": "2.764.0",
+              "resolved": "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.764.0.tgz#587bf954645bbcb706c0ce985e7befeb94b15427",
+              "integrity": "sha512-0asgRwAI3WxUyOjlx2fL7pPHEZajFbAVRerE2h0xX649123PwdhIiJ2HM7lWwn/f+mX7IagYjOCn9dIyvCHBVQ==",
+              "dev": true,
+              "requires": {
+                "buffer": "4.9.2",
+                "events": "1.1.1",
+                "ieee754": "1.1.13",
+                "jmespath": "0.15.0",
+                "querystring": "0.2.0",
+                "sax": "1.2.1",
+                "url": "0.10.3",
+                "uuid": "3.3.2",
+                "xml2js": "0.4.19"
+              },
+              "dependencies": {
+                "buffer": {
+                  "version": "4.9.2",
+                  "resolved": "https://registry.yarnpkg.com/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8",
+                  "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+                  "dev": true,
+                  "requires": {
+                    "base64-js": "^1.0.2",
+                    "ieee754": "^1.1.4",
+                    "isarray": "^1.0.0"
+                  }
+                }
+              }
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "resolved": "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767",
+              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+              "dev": true
+            },
+            "base64-js": {
+              "version": "1.3.1",
+              "resolved": "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1",
+              "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+              "dev": true
+            },
+            "bl": {
+              "version": "4.0.3",
+              "resolved": "https://registry.yarnpkg.com/bl/-/bl-4.0.3.tgz#12d6287adc29080e22a705e5764b2a9522cdc489",
+              "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+              "dev": true,
+              "requires": {
+                "buffer": "^5.5.0",
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.4.0"
+              },
+              "dependencies": {
+                "readable-stream": {
+                  "version": "3.6.0",
+                  "resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198",
+                  "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                  "dev": true,
+                  "requires": {
+                    "inherits": "^2.0.3",
+                    "string_decoder": "^1.1.1",
+                    "util-deprecate": "^1.0.1"
+                  }
+                },
+                "safe-buffer": {
+                  "version": "5.2.1",
+                  "resolved": "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6",
+                  "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+                  "dev": true
+                },
+                "string_decoder": {
+                  "version": "1.3.0",
+                  "resolved": "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e",
+                  "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+                  "dev": true,
+                  "requires": {
+                    "safe-buffer": "~5.2.0"
+                  }
+                }
+              }
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "resolved": "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd",
+              "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+              "dev": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "buffer": {
+              "version": "5.6.0",
+              "resolved": "https://registry.yarnpkg.com/buffer/-/buffer-5.6.0.tgz#a31749dc7d81d84db08abf937b6b8c4033f62786",
+              "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+              "dev": true,
+              "requires": {
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4"
+              }
+            },
+            "buffer-crc32": {
+              "version": "0.2.13",
+              "resolved": "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242",
+              "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+              "dev": true
+            },
+            "cliui": {
+              "version": "7.0.1",
+              "resolved": "https://registry.yarnpkg.com/cliui/-/cliui-7.0.1.tgz#a4cb67aad45cd83d8d05128fc9f4d8fbb887e6b3",
+              "integrity": "sha512-rcvHOWyGyid6I1WjT/3NatKj2kDt9OdSHSXpyLXaMWFbKpGACNW8pRhhdPUq9MWUOdwn8Rz9AVETjF4105rZZQ==",
+              "dev": true,
+              "requires": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0",
+                "wrap-ansi": "^7.0.0"
+              }
+            },
+            "color-convert": {
+              "version": "2.0.1",
+              "resolved": "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3",
+              "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+              "dev": true,
+              "requires": {
+                "color-name": "~1.1.4"
+              }
+            },
+            "color-name": {
+              "version": "1.1.4",
+              "resolved": "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2",
+              "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+              "dev": true
+            },
+            "compress-commons": {
+              "version": "4.0.1",
+              "resolved": "https://registry.yarnpkg.com/compress-commons/-/compress-commons-4.0.1.tgz#c5fa908a791a0c71329fba211d73cd2a32005ea8",
+              "integrity": "sha512-xZm9o6iikekkI0GnXCmAl3LQGZj5TBDj0zLowsqi7tJtEa3FMGSEcHcqrSJIrOAk1UG/NBbDn/F1q+MG/p/EsA==",
+              "dev": true,
+              "requires": {
+                "buffer-crc32": "^0.2.13",
+                "crc32-stream": "^4.0.0",
+                "normalize-path": "^3.0.0",
+                "readable-stream": "^3.6.0"
+              },
+              "dependencies": {
+                "readable-stream": {
+                  "version": "3.6.0",
+                  "resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198",
+                  "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                  "dev": true,
+                  "requires": {
+                    "inherits": "^2.0.3",
+                    "string_decoder": "^1.1.1",
+                    "util-deprecate": "^1.0.1"
+                  }
+                },
+                "safe-buffer": {
+                  "version": "5.2.1",
+                  "resolved": "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6",
+                  "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+                  "dev": true
+                },
+                "string_decoder": {
+                  "version": "1.3.0",
+                  "resolved": "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e",
+                  "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+                  "dev": true,
+                  "requires": {
+                    "safe-buffer": "~5.2.0"
+                  }
+                }
+              }
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "resolved": "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b",
+              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+              "dev": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "resolved": "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7",
+              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+              "dev": true
+            },
+            "crc": {
+              "version": "3.8.0",
+              "resolved": "https://registry.yarnpkg.com/crc/-/crc-3.8.0.tgz#ad60269c2c856f8c299e2c4cc0de4556914056c6",
+              "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+              "dev": true,
+              "requires": {
+                "buffer": "^5.1.0"
+              }
+            },
+            "crc32-stream": {
+              "version": "4.0.0",
+              "resolved": "https://registry.yarnpkg.com/crc32-stream/-/crc32-stream-4.0.0.tgz#05b7ca047d831e98c215538666f372b756d91893",
+              "integrity": "sha512-tyMw2IeUX6t9jhgXI6um0eKfWq4EIDpfv5m7GX4Jzp7eVelQ360xd8EPXJhp2mHwLQIkqlnMLjzqSZI3a+0wRw==",
+              "dev": true,
+              "requires": {
+                "crc": "^3.4.4",
+                "readable-stream": "^3.4.0"
+              },
+              "dependencies": {
+                "readable-stream": {
+                  "version": "3.6.0",
+                  "resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198",
+                  "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                  "dev": true,
+                  "requires": {
+                    "inherits": "^2.0.3",
+                    "string_decoder": "^1.1.1",
+                    "util-deprecate": "^1.0.1"
+                  }
+                },
+                "safe-buffer": {
+                  "version": "5.2.1",
+                  "resolved": "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6",
+                  "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+                  "dev": true
+                },
+                "string_decoder": {
+                  "version": "1.3.0",
+                  "resolved": "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e",
+                  "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+                  "dev": true,
+                  "requires": {
+                    "safe-buffer": "~5.2.0"
+                  }
+                }
+              }
+            },
+            "emoji-regex": {
+              "version": "8.0.0",
+              "resolved": "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37",
+              "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+              "dev": true
+            },
+            "end-of-stream": {
+              "version": "1.4.4",
+              "resolved": "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0",
+              "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+              "dev": true,
+              "requires": {
+                "once": "^1.4.0"
+              }
+            },
+            "escalade": {
+              "version": "3.1.0",
+              "resolved": "https://registry.yarnpkg.com/escalade/-/escalade-3.1.0.tgz#e8e2d7c7a8b76f6ee64c2181d6b8151441602d4e",
+              "integrity": "sha512-mAk+hPSO8fLDkhV7V0dXazH5pDc6MrjBTPyD3VeKzxnVFjH1MIxbCdqGZB9O8+EwWakZs3ZCbDS4IpRt79V1ig==",
+              "dev": true
+            },
+            "events": {
+              "version": "1.1.1",
+              "resolved": "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924",
+              "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+              "dev": true
+            },
+            "fs-constants": {
+              "version": "1.0.0",
+              "resolved": "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad",
+              "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+              "dev": true
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "resolved": "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f",
+              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+              "dev": true
+            },
+            "get-caller-file": {
+              "version": "2.0.5",
+              "resolved": "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e",
+              "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+              "dev": true
+            },
+            "glob": {
+              "version": "7.1.6",
+              "resolved": "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6",
+              "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+              "dev": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "graceful-fs": {
+              "version": "4.2.4",
+              "resolved": "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb",
+              "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+              "dev": true
+            },
+            "ieee754": {
+              "version": "1.1.13",
+              "resolved": "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84",
+              "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+              "dev": true
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "resolved": "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9",
+              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+              "dev": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.4",
+              "resolved": "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c",
+              "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "3.0.0",
+              "resolved": "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d",
+              "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+              "dev": true
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "resolved": "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+              "dev": true
+            },
+            "jmespath": {
+              "version": "0.15.0",
+              "resolved": "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217",
+              "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+              "dev": true
+            },
+            "jsonschema": {
+              "version": "1.2.7",
+              "resolved": "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.2.7.tgz#4e6d6dc4d83dc80707055ba22c00ec6152c0e6e9",
+              "integrity": "sha512-3dFMg9hmI9LdHag/BRIhMefCfbq1hicvYMy8YhZQorAdzOzWz7NjniSpn39yjpzUAMIWtGyyZuH2KNBloH7ZLw==",
+              "dev": true
+            },
+            "lazystream": {
+              "version": "1.0.0",
+              "resolved": "https://registry.yarnpkg.com/lazystream/-/lazystream-1.0.0.tgz#f6995fe0f820392f61396be89462407bb77168e4",
+              "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+              "dev": true,
+              "requires": {
+                "readable-stream": "^2.0.5"
+              }
+            },
+            "lodash.defaults": {
+              "version": "4.2.0",
+              "resolved": "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c",
+              "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
+              "dev": true
+            },
+            "lodash.difference": {
+              "version": "4.5.0",
+              "resolved": "https://registry.yarnpkg.com/lodash.difference/-/lodash.difference-4.5.0.tgz#9ccb4e505d486b91651345772885a2df27fd017c",
+              "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
+              "dev": true
+            },
+            "lodash.flatten": {
+              "version": "4.4.0",
+              "resolved": "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f",
+              "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
+              "dev": true
+            },
+            "lodash.isplainobject": {
+              "version": "4.0.6",
+              "resolved": "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb",
+              "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+              "dev": true
+            },
+            "lodash.union": {
+              "version": "4.6.0",
+              "resolved": "https://registry.yarnpkg.com/lodash.union/-/lodash.union-4.6.0.tgz#48bb5088409f16f1821666641c44dd1aaae3cd88",
+              "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
+              "dev": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "resolved": "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083",
+              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+              "dev": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "normalize-path": {
+              "version": "3.0.0",
+              "resolved": "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65",
+              "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+              "dev": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "resolved": "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1",
+              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+              "dev": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "resolved": "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f",
+              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+              "dev": true
+            },
+            "process-nextick-args": {
+              "version": "2.0.1",
+              "resolved": "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2",
+              "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+              "dev": true
+            },
+            "punycode": {
+              "version": "1.3.2",
+              "resolved": "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d",
+              "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+              "dev": true
+            },
+            "querystring": {
+              "version": "0.2.0",
+              "resolved": "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620",
+              "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+              "dev": true
+            },
+            "readable-stream": {
+              "version": "2.3.7",
+              "resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57",
+              "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "readdir-glob": {
+              "version": "1.1.0",
+              "resolved": "https://registry.yarnpkg.com/readdir-glob/-/readdir-glob-1.1.0.tgz#a3def6f7b61343e8a1274dbb872b9a2ad055d086",
+              "integrity": "sha512-KgT0oXPIDQRRRYFf+06AUaodICTep2Q5635BORLzTEzp7rEqcR14a47j3Vzm3ix7FeI1lp8mYyG7r8lTB06Pyg==",
+              "dev": true,
+              "requires": {
+                "minimatch": "^3.0.4"
+              }
+            },
+            "require-directory": {
+              "version": "2.1.1",
+              "resolved": "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42",
+              "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+              "dev": true
+            },
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true
+            },
+            "sax": {
+              "version": "1.2.1",
+              "resolved": "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a",
+              "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
+              "dev": true
+            },
+            "semver": {
+              "version": "7.3.2",
+              "resolved": "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938",
+              "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+              "dev": true
+            },
+            "string-width": {
+              "version": "4.2.0",
+              "resolved": "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5",
+              "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+              "dev": true,
+              "requires": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.0"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "resolved": "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "6.0.0",
+              "resolved": "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532",
+              "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^5.0.0"
+              }
+            },
+            "tar-stream": {
+              "version": "2.1.4",
+              "resolved": "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.1.4.tgz#c4fb1a11eb0da29b893a5b25476397ba2d053bfa",
+              "integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
+              "dev": true,
+              "requires": {
+                "bl": "^4.0.3",
+                "end-of-stream": "^1.4.1",
+                "fs-constants": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1"
+              },
+              "dependencies": {
+                "readable-stream": {
+                  "version": "3.6.0",
+                  "resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198",
+                  "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                  "dev": true,
+                  "requires": {
+                    "inherits": "^2.0.3",
+                    "string_decoder": "^1.1.1",
+                    "util-deprecate": "^1.0.1"
+                  }
+                },
+                "safe-buffer": {
+                  "version": "5.2.1",
+                  "resolved": "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6",
+                  "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+                  "dev": true
+                },
+                "string_decoder": {
+                  "version": "1.3.0",
+                  "resolved": "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e",
+                  "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+                  "dev": true,
+                  "requires": {
+                    "safe-buffer": "~5.2.0"
+                  }
+                }
+              }
+            },
+            "url": {
+              "version": "0.10.3",
+              "resolved": "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64",
+              "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+              "dev": true,
+              "requires": {
+                "punycode": "1.3.2",
+                "querystring": "0.2.0"
+              }
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "resolved": "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf",
+              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+              "dev": true
+            },
+            "uuid": {
+              "version": "3.3.2",
+              "resolved": "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131",
+              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+              "dev": true
+            },
+            "wrap-ansi": {
+              "version": "7.0.0",
+              "resolved": "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43",
+              "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "resolved": "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f",
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+              "dev": true
+            },
+            "xml2js": {
+              "version": "0.4.19",
+              "resolved": "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7",
+              "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+              "dev": true,
+              "requires": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~9.0.1"
+              },
+              "dependencies": {
+                "sax": {
+                  "version": "1.2.4",
+                  "resolved": "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9",
+                  "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+                  "dev": true
+                }
+              }
+            },
+            "xmlbuilder": {
+              "version": "9.0.7",
+              "resolved": "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d",
+              "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+              "dev": true
+            },
+            "y18n": {
+              "version": "5.0.1",
+              "resolved": "https://registry.yarnpkg.com/y18n/-/y18n-5.0.1.tgz#1ad2a7eddfa8bce7caa2e1f6b5da96c39d99d571",
+              "integrity": "sha512-/jJ831jEs4vGDbYPQp4yGKDYPSCCEQ45uZWJHE1AoYBzqdZi8+LDWas0z4HrmJXmKdpFsTiowSHXdxyFhpmdMg==",
+              "dev": true
+            },
+            "yargs": {
+              "version": "16.0.3",
+              "resolved": "https://registry.yarnpkg.com/yargs/-/yargs-16.0.3.tgz#7a919b9e43c90f80d4a142a89795e85399a7e54c",
+              "integrity": "sha512-6+nLw8xa9uK1BOEOykaiYAJVh6/CjxWXK/q9b5FpRgNslt8s22F2xMBqVIKgCRjNgGvGPBy8Vog7WN7yh4amtA==",
+              "dev": true,
+              "requires": {
+                "cliui": "^7.0.0",
+                "escalade": "^3.0.2",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.0",
+                "y18n": "^5.0.1",
+                "yargs-parser": "^20.0.0"
+              }
+            },
+            "yargs-parser": {
+              "version": "20.2.0",
+              "resolved": "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.0.tgz#944791ca2be2e08ddadd3d87e9de4c6484338605",
+              "integrity": "sha512-2agPoRFPoIcFzOIp6656gcvsg2ohtscpw2OINr/q46+Sq41xz2OYLqx5HRHabmFU1OARIPAYH5uteICE7mn/5A==",
+              "dev": true
+            },
+            "zip-stream": {
+              "version": "4.0.2",
+              "resolved": "https://registry.yarnpkg.com/zip-stream/-/zip-stream-4.0.2.tgz#3a20f1bd7729c2b59fd4efa04df5eb7a5a217d2e",
+              "integrity": "sha512-TGxB2g+1ur6MHkvM644DuZr8Uzyz0k0OYWtS3YlpfWBEmK4woaC2t3+pozEL3dBfIPmpgmClR5B2QRcMgGt22g==",
+              "dev": true,
+              "requires": {
+                "archiver-utils": "^2.1.0",
+                "compress-commons": "^4.0.0",
+                "readable-stream": "^3.6.0"
+              },
+              "dependencies": {
+                "readable-stream": {
+                  "version": "3.6.0",
+                  "resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198",
+                  "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                  "dev": true,
+                  "requires": {
+                    "inherits": "^2.0.3",
+                    "string_decoder": "^1.1.1",
+                    "util-deprecate": "^1.0.1"
+                  }
+                },
+                "safe-buffer": {
+                  "version": "5.2.1",
+                  "resolved": "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6",
+                  "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+                  "dev": true
+                },
+                "string_decoder": {
+                  "version": "1.3.0",
+                  "resolved": "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e",
+                  "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+                  "dev": true,
+                  "requires": {
+                    "safe-buffer": "~5.2.0"
+                  }
+                }
+              }
+            }
           }
         },
         "charenc": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@aws-cdk/aws-dms": "^1.66.0",
     "@aws-cdk/aws-ec2": "^1.66.0",
+    "@aws-cdk/aws-glue": "^1.66.0",
     "@aws-cdk/aws-iam": "^1.66.0",
     "@aws-cdk/aws-rds": "^1.66.0",
     "@aws-cdk/aws-s3": "^1.66.0",


### PR DESCRIPTION
Uses the settings described [here](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Target.S3.html#CHAP_Target.S3.Configuring) and [here](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Target.S3.html#CHAP_Target.S3.Configuring.InsertOps) to include the operation performed (insert, update or delete). This will add a column in the Parquet format called `Op`. The column is not found in the full load files unless it is stored as CSV in S3.

A Glue crawler and database have been added. For the full load files the `Op` column will be null.